### PR TITLE
Fixed bug with lost chat messages when the chat was opened in new window

### DIFF
--- a/src/stores/ChatStore.js
+++ b/src/stores/ChatStore.js
@@ -71,7 +71,7 @@ function update(state = DEFAULT_STATE, action) {
 
 					// Concat this event to chats to be displayed
 					new_state.chats = state.chats.concat({
-						[Date.now()]: {
+						[action.detail.timestamp]: {
 							...action.detail
 						}
 					});
@@ -84,7 +84,7 @@ function update(state = DEFAULT_STATE, action) {
 
 					// Concat this event to chats to be displayed
 					new_state.chats = state.chats.concat({
-						[Date.now()]: {
+						[action.detail.timestamp]: {
 							...action.detail
 						}
 					});
@@ -95,7 +95,7 @@ function update(state = DEFAULT_STATE, action) {
 				case 'chat.request.rating':
 				case 'chat.msg':
 					new_state.chats = state.chats.concat({
-						[Date.now()]: {
+						[action.detail.timestamp]: {
 							...action.detail,
 							...member(state, action.detail)
 						}


### PR DESCRIPTION
Not all messages are always displayed if you open an active chat with a chat message history in a new window. If you just open a chat in a new window, then all messages can be displayed but not always. Sometimes some of these can be lost and not displayed. Sometimes, to recreate this issue, you need to reload a page many times in a new window or open chat in new window on every step. This fix has helped me in my project. The issue may not occur on development environment.