### PR TITLE
Fix agent rating request not rendering

### DIFF
--- a/src/components/MessageList.js
+++ b/src/components/MessageList.js
@@ -55,8 +55,13 @@ class MessageList extends Component {
             message={msg}
           />
         );
-      case 'chat.rating':
-        return <ChatRating key={msg.type + msg.timestamp}/>;
+      case 'chat.request.rating':
+        return (
+          <ChatRating
+            key={msg.type + msg.timestamp}
+            agent={this.props.agents[msg.nick]}
+          />
+        );
       case 'offline':
         return <OfflineForm key="offline" />;
       case 'prechat':


### PR DESCRIPTION
Current implementation does not catch `chat.request.rating`, which results in the message list rendering like below.

![screen shot 2019-02-07 at 11 00 44 am](https://user-images.githubusercontent.com/8565916/52388169-21c69900-2ac8-11e9-8b63-59c0f36b48c4.png)

The should fix the issue and render the request correctly.

![screen shot 2019-02-07 at 11 02 02 am](https://user-images.githubusercontent.com/8565916/52388198-43c01b80-2ac8-11e9-900c-f5e5ad853051.png)

